### PR TITLE
Improved lineno performance (20%).

### DIFF
--- a/typedlua/tlchecker.lua
+++ b/typedlua/tlchecker.lua
@@ -26,14 +26,8 @@ local check_block, check_stm, check_exp, check_var
 
 local function lineno (s, i)
   if i == 1 then return 1, 1 end
-  local l, lastline = 0, ""
-  s = s:sub(1, i) .. "\n"
-  for line in s:gmatch("[^\n]*[\n]") do
-    l = l + 1
-    lastline = line
-  end
-  local c = lastline:len() - 1
-  return l, c ~= 0 and c or 1
+  local rest, num = s:sub(1,i):gsub("[^\n]*\n", "")
+  return 1 + num, #rest
 end
 
 function typeerror (env, msg, pos)


### PR DESCRIPTION
This version is about 20% faster based on my testing. Here is the script I used:

``` lua
-- lineno.lua
local function linenonew(s, i)
  if i == 1 then return 1, 1 end
  local rest, num = s:sub(1,i):gsub("[^\n]*\n", "")
  return 1 + num, #rest
end

local function lineno (s, i)
  if i == 1 then return 1, 1 end
  local l, lastline = 0, ""
  s = s:sub(1, i) .. "\n"
  for line in s:gmatch("[^\n]*[\n]") do
    l = l + 1
    lastline = line
  end
  local c = lastline:len() - 1
  return l, c ~= 0 and c or 1
end

local str = (io.open('lineno.lua'):read('*a')):rep(50)
print('measuring', #str)
local s = os.clock()
for i = 1, #str do
  linenonew(str, i)
end
print('linenonew', os.clock()-s)
local s = os.clock()
for i = 1, #str do
  lineno(str, i)
end
print('lineno', os.clock()-s)
```
