### PR TITLE
Support "," in the end of a table, like Lua.

### DIFF
--- a/typedlua/tldparser.lua
+++ b/typedlua/tldparser.lua
@@ -60,7 +60,7 @@ local G = lpeg.P { "TypedLuaDescription";
   TupleType = lpeg.Ct(lpeg.V("Type") * (tllexer.symb(",") * lpeg.V("Type"))^0) *
               (tllexer.symb("*") * lpeg.Cc(true))^-1 /
               tltype.Tuple;
-  TableType = tllexer.symb("{") * lpeg.V("TableTypeBody") * tllexer.symb("}") /
+  TableType = tllexer.symb("{") * lpeg.V("TableTypeBody") * tllexer.symb(",")^-1 * tllexer.symb("}") /
               tltype.Table;
   TableTypeBody = lpeg.V("RecordType") +
                   lpeg.V("HashType") +


### PR DESCRIPTION
Allow syntax such as

```
foo : {
   "bar": string,
   "baz": boolean,
}
```

Note the "," after boolean. My change to the parser was simplistic, and accepts ```{,}``` as a synonym to ```{}``` (which Lua doesn't — is this a problem? I didn't want to make more drastic changes, since I suck at lpeg)