### PR TITLE
Use actual file path in error messages.

### DIFF
--- a/examples/bootstrap/tlchecker.tl
+++ b/examples/bootstrap/tlchecker.tl
@@ -164,7 +164,7 @@ local function check_tl (env, name, path)
   io.close(file)
   local ast = assert(tlparser.parse(subject, path, env.strict))
   env.subject = subject
-  env.filename = name .. ".tl"
+  env.filename = path
   tlst.begin_function(env)
   check_block(env, ast)
   local t1 = tltype.first(infer_return_type(env))

--- a/typedlua/tlchecker.lua
+++ b/typedlua/tlchecker.lua
@@ -168,7 +168,7 @@ local function check_tl (env, name, path)
   io.close(file)
   local ast = assert(tlparser.parse(subject, path, env.strict, env.integer))
   env.subject = subject
-  env.filename = name .. ".tl"
+  env.filename = path
   tlst.begin_function(env)
   check_block(env, ast)
   local t1 = tltype.first(infer_return_type(env))


### PR DESCRIPTION
When using files in submodules, such as foo/bar.tl,
I was getting error messages that said foo.bar.tl:57:28:
My text editor recognizes the 'file:lin:col:' syntax
so I'm used to copy-and-paste the path from error messages
into the editor (thanks for using the same syntax as GCC :) )
and the conversion of `/` into `.` was making it choke.