### PR TITLE
Improve inference of "and".

### DIFF
--- a/typedlua/tlchecker.lua
+++ b/typedlua/tlchecker.lua
@@ -399,6 +399,8 @@ local function check_and (env, exp)
     set_type(exp, tltype.Union(t2, Nil))
   elseif tltype.isUnion(t1, False) then
     set_type(exp, tltype.Union(t2, False))
+  elseif tltype.isBoolean(t1) then
+    set_type(exp, tltype.Union(t2, False))
   else
     set_type(exp, tltype.Union(t1, t2))
   end


### PR DESCRIPTION
The goal here was to make the "ternary operator" idiom `V = A and B or C` work.

Test case:
```lua
local y = 1
local x = y > 9 and "yes" or "no"
print(string.match(x, "yes"))
```

With this patch, x is correctly inferred to be `string`.

The idea is that, in `A and B`, if A is inferred to be a boolean,
then the only boolean it can be is false, because if it is true,
then the expression will return B.

Once that `A and B` becomes `false|B`, then the existing
implementation of `(A and B) or C` takes care of the rest.

With the simplicity of this fix, I begin to fully appreciate
the elegance of having literal types in the language!!