### PR TITLE
Safer env for recursives + variable identity.

### DIFF
--- a/typedlua/tltype.lua
+++ b/typedlua/tltype.lua
@@ -743,7 +743,10 @@ end
 
 local function subtype_variable (env, t1, t2)
   if tltype.isVariable(t1) and tltype.isVariable(t2) then
-    return env[t1[1] .. t2[1]]
+    if t1[1] == t2[1] then
+      return true
+    end
+    return env[t1[1] .."@".. t2[1]]
   else
     return false
   end
@@ -751,18 +754,18 @@ end
 
 local function subtype_recursive (env, t1, t2, relation)
   if tltype.isRecursive(t1) and tltype.isRecursive(t2) then
-    env[t1[1] .. t2[1]] = true
+    env[t1[1] .."@".. t2[1]] = true
     return subtype(env, t1[2], t2[2], relation)
   elseif tltype.isRecursive(t1) and not tltype.isRecursive(t2) then
-    if not env[t1[1] .. t1[1]] then
-      env[t1[1] .. t1[1]] = true
+    if not env[t1[1] .."@".. t1[1]] then
+      env[t1[1] .."@".. t1[1]] = true
       return subtype(env, t1[2], t2, relation)
     else
       return subtype(env, tltype.Variable(t1[1]), t2, relation)
     end
   elseif not tltype.isRecursive(t1) and tltype.isRecursive(t2) then
-    if not env[t2[1] .. t2[1]] then
-      env[t2[1] .. t2[1]] = true
+    if not env[t2[1] .."@".. t2[1]] then
+      env[t2[1] .."@".. t2[1]] = true
       return subtype(env, t1, t2[2], relation)
     else
       return subtype(env, t1, tltype.Variable(t2[1]), relation)


### PR DESCRIPTION
The change with the "@" characters is a bit of paranoia, as different pairs of types may concatenate to the same string ("aa".."b" and "a".."ab") and this may cause evaluation errors in the future.

Note the change in `subtype_variable` for when the two entries have equal names. This is the important one. Please verify if this is semantically correct. Here it seems to solve #55, but I don't know if that's enough. Maybe this is just hiding the real problem.

I don't know if I'm understanding correctly the way the structural type system is supposed to work. With this patch, the code in #55 gives no errors, but the variant below still fails:

```lua
interface ELEM
   x: integer
end

interface OBJ
   parent: OBJ?
   atr: ELEM -- if I change ELEM to {"x":integer}, I no longer get an error
end

local function f(o:OBJ)
   local parent = o.parent
   if parent then
      f({atr={x=2}}) -- isn't this structurally equivalent to OBJ?
   end
end
```