### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+sudo: false
+
+env:
+  - LUA="lua=5.1"
+  - LUA="lua=5.2"
+  - LUA="lua=5.3"
+  - LUA="luajit=2.0"
+  - LUA="luajit=2.1"
+
+before_install:
+  - pip install hererocks
+  - hererocks lua_install -r^ --$LUA
+  - export PATH=$PATH:$PWD/lua_install/bin
+  - luarocks install luacheck
+  - luarocks install luacov
+#  - luarocks install luacov-coveralls
+
+install:
+  - luarocks make
+
+script:
+  # Don't fail due to luacheck
+  - luacheck --std max tlc typedlua test.lua || true
+  - lua -lluacov test.lua
+
+#after_success:
+#  - luacov-coveralls -e $TRAVIS_BUILD_DIR/lua_install

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Typed Lua
+[![Build Status](https://travis-ci.org/andremm/typedlua.svg?branch=master)](https://travis-ci.org/andremm/typedlua)
 
 Typed Lua is a typed superset of Lua that compiles to plain Lua.
 It provides optional type annotations, compile-time type checking, and


### PR DESCRIPTION
This adds support for the Travis CI continuous integration. In addition it shows the tests are currently failing on all recent versions of Lua.