### PR TITLE
Fix some warnings pointed by luacheck.

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -11,41 +11,41 @@ local e, r, s
 
 local filename = "test.lua"
 
-local function parse (s)
-  local t,m = tlparser.parse(s,filename,false,false)
-  local r
+local function parse (my_s)
+  local t,m = tlparser.parse(my_s,filename,false,false)
+  local my_r
   if not t then
-    r = m
+    my_r = m
   else
-    r = tlast.tostring(t)
+    my_r = tlast.tostring(t)
   end
-  return r .. "\n"
+  return my_r .. "\n"
 end
 
-local function typecheck (s)
-  local t,m = tlparser.parse(s,filename,false,false)
-  local r
+local function typecheck (my_s)
+  local t,m = tlparser.parse(my_s,filename,false,false)
+  local my_r
   if not t then
     error(m)
     os.exit(1)
   end
-  m = tlchecker.typecheck(t,s,filename,false,false)
+  m = tlchecker.typecheck(t,my_s,filename,false,false)
   m = tlchecker.error_msgs(m,false)
   if m then
-    r = m
+    my_r = m
   else
-    r = tlast.tostring(t)
+    my_r = tlast.tostring(t)
   end
-  return r .. "\n"
+  return my_r .. "\n"
 end
 
-local function generate (s)
-  local t,m = tlparser.parse(s,filename,false,false)
+local function generate (my_s)
+  local t,m = tlparser.parse(my_s,filename,false,false)
   if not t then
     error(m)
     os.exit(1)
   end
-  m = tlchecker.typecheck(t,s,filename,false,false)
+  m = tlchecker.typecheck(t,my_s,filename,false,false)
   m = tlchecker.error_msgs(m,false)
   if m then
     return m .. "\n"

--- a/tlc
+++ b/tlc
@@ -124,8 +124,9 @@ if PRINTAST then
   os.exit(0)
 end
 
-local error_msg = tlchecker.typecheck(ast, subject, filename, STRICT, INTEGER)
-local error_msg, status = tlchecker.error_msgs(error_msg, WARNINGS)
+error_msg = tlchecker.typecheck(ast, subject, filename, STRICT, INTEGER)
+local status
+error_msg, status = tlchecker.error_msgs(error_msg, WARNINGS)
 if error_msg then print(error_msg) end
 
 local generated_code = tlcode.generate(ast)

--- a/typedlua/tlast.lua
+++ b/typedlua/tlast.lua
@@ -336,7 +336,7 @@ function tlast.exprSuffixed (e1, e2)
   if e2 then
     if e2.tag == "Call" or e2.tag == "Invoke" then
       local e = { tag = e2.tag, pos = e1.pos, [1] = e1 }
-      for k, v in ipairs(e2) do
+      for _, v in ipairs(e2) do
         table.insert(e, v)
       end
       return e
@@ -426,7 +426,7 @@ end
 local function fixed_string (str)
   local new_str = ""
   for i=1,string.len(str) do
-    char = string.byte(str, i)
+    local char = string.byte(str, i)
     if char == 34 then new_str = new_str .. string.format("\\\"")
     elseif char == 92 then new_str = new_str .. string.format("\\\\")
     elseif char == 7 then new_str = new_str .. string.format("\\a")
@@ -679,13 +679,11 @@ function stm2str (stm)
     str = str .. "{ "
     local len = #stm
     if len % 2 == 0 then
-      local l = {}
       for i=1,len-2,2 do
         str = str .. exp2str(stm[i]) .. ", " .. block2str(stm[i+1]) .. ", "
       end
       str = str .. exp2str(stm[len-1]) .. ", " .. block2str(stm[len])
     else
-      local l = {}
       for i=1,len-3,2 do
         str = str .. exp2str(stm[i]) .. ", " .. block2str(stm[i+1]) .. ", "
       end

--- a/typedlua/tlcode.lua
+++ b/typedlua/tlcode.lua
@@ -4,7 +4,7 @@ This file implements the code generator for Typed Lua
 local tlcode = {}
 
 local code_block, code_stm, code_exp, code_var
-local code_explist, code_varlist, code_fieldlist, code_idlist
+local code_explist, code_varlist
 
 local function spaces (fmt)
   return string.rep(" ", 2 * fmt.indent)
@@ -26,7 +26,7 @@ end
 local function fix_str (str)
   local new_str = ""
   for i=1,string.len(str) do
-    char = string.byte(str, i)
+    local char = string.byte(str, i)
     if char == 34 then new_str = new_str .. string.format("\\\"")
     elseif char == 92 then new_str = new_str .. string.format("\\\\")
     elseif char == 7 then new_str = new_str .. string.format("\\a")
@@ -97,7 +97,6 @@ local function code_parlist (parlist, fmt)
     is_vararg = true
     len = len - 1
   end
-  local k = 1
   for k=1, len do
     l[k] = code_var(parlist[k], fmt)
   end

--- a/typedlua/tldparser.lua
+++ b/typedlua/tldparser.lua
@@ -9,7 +9,6 @@ lpeg.locale(lpeg)
 
 local tlast = require "typedlua.tlast"
 local tllexer = require "typedlua.tllexer"
-local tlst = require "typedlua.tlst"
 local tltype = require "typedlua.tltype"
 
 local G = lpeg.P { "TypedLuaDescription";
@@ -107,7 +106,7 @@ local function traverse (ast, errorinfo, strict)
   assert(type(errorinfo) == "table")
   assert(type(strict) == "boolean")
   local t = tltype.Table()
-  for k, v in ipairs(ast) do
+  for _, v in ipairs(ast) do
     local tag = v.tag
     if tag == "Id" then
       table.insert(t, tltype.Field(v.const, tltype.Literal(v[1]), v[2]))
@@ -127,7 +126,7 @@ local function traverse (ast, errorinfo, strict)
         return nil, tllexer.syntaxerror(errorinfo.subject, v.pos, errorinfo.filename, msg)
       end
       if tltype.checkRecursive(t, name) then
-        local msg = string.format("userdata '%s' is recursive", name)
+        msg = string.format("userdata '%s' is recursive", name)
         return nil, tllexer.syntaxerror(errorinfo.subject, v.pos, errorinfo.filename, msg)
       end
     else

--- a/typedlua/tlparser.lua
+++ b/typedlua/tlparser.lua
@@ -300,7 +300,7 @@ local function traverse_paren (env, exp)
 end
 
 local function traverse_table (env, fieldlist)
-  for k, v in ipairs(fieldlist) do
+  for _, v in ipairs(fieldlist) do
     local tag = v.tag
     if tag == "Pair" or tag == "Const" then
       local status, msg = traverse_exp(env, v[1])
@@ -445,7 +445,7 @@ end
 local function traverse_local (env, stm)
   local status, msg = traverse_explist(env, stm[2])
   if not status then return status, msg end
-  for k, v in ipairs(stm[1]) do
+  for _, v in ipairs(stm[1]) do
     tlst.set_local(env, v)
   end
   return true
@@ -519,7 +519,7 @@ function traverse_var (env, var)
 end
 
 function traverse_varlist (env, varlist)
-  for k, v in ipairs(varlist) do
+  for _, v in ipairs(varlist) do
     local status, msg = traverse_var(env, v)
     if not status then return status, msg end
   end
@@ -557,7 +557,7 @@ function traverse_exp (env, exp)
 end
 
 function traverse_explist (env, explist)
-  for k, v in ipairs(explist) do
+  for _, v in ipairs(explist) do
     local status, msg = traverse_exp(env, v)
     if not status then return status, msg end
   end
@@ -606,9 +606,8 @@ function traverse_stm (env, stm)
 end
 
 function traverse_block (env, block)
-  local l = {}
   tlst.begin_scope(env)
-  for k, v in ipairs(block) do
+  for _, v in ipairs(block) do
     local status, msg = traverse_stm(env, v)
     if not status then return status, msg end
   end
@@ -618,7 +617,7 @@ end
 
 local function verify_pending_gotos (env)
   for s = tlst.get_maxscope(env), 1, -1 do
-    for k, v in ipairs(tlst.get_pending_gotos(env, s)) do
+    for _, v in ipairs(tlst.get_pending_gotos(env, s)) do
       local l = v[1]
       if not tlst.exist_label(env, s, l) then
         local msg = string.format("no visible label '%s' for <goto>", l)
@@ -639,13 +638,13 @@ local function traverse (ast, errorinfo, strict)
   tlst.set_vararg(env, tltype.String())
   tlst.begin_scope(env)
   tlst.set_local(env, _env)
-  for k, v in ipairs(ast) do
+  for _, v in ipairs(ast) do
     local status, msg = traverse_stm(env, v)
     if not status then return status, msg end
   end
   tlst.end_scope(env)
   tlst.end_function(env)
-  status, msg = verify_pending_gotos(env)
+  local status, msg = verify_pending_gotos(env)
   if not status then return status, msg end
   return ast
 end

--- a/typedlua/tlst.lua
+++ b/typedlua/tlst.lua
@@ -40,7 +40,7 @@ end
 function tlst.begin_scope (env)
   local scope = env.scope
   if scope > 0 then
-    for k, v in pairs(env[scope]["local"]) do
+    for _, v in pairs(env[scope]["local"]) do
       if v["type"] and v["type"].open then
         v["type"].open = nil
         v["type"].reopen = true
@@ -57,7 +57,7 @@ function tlst.end_scope (env)
   env.scope = env.scope - 1
   local scope = env.scope
   if scope > 0 then
-    for k, v in pairs(env[scope]["local"]) do
+    for _, v in pairs(env[scope]["local"]) do
       if v.assigned and v.bkp then
         v["type"] = v.bkp
       end
@@ -208,7 +208,7 @@ function tlst.set_vararg (env, t)
 end
 
 -- get_vararg : (env) -> (type?)
-function tlst.get_vararg (env, t)
+function tlst.get_vararg (env)
   return env["function"][env.fscope]["vararg"]
 end
 

--- a/typedlua/tltype.lua
+++ b/typedlua/tltype.lua
@@ -245,7 +245,7 @@ function tltype.isUnion (t1, t2)
     return t1.tag == "TUnion"
   else
     if t1.tag == "TUnion" then
-      for k, v in ipairs(t1) do
+      for _, v in ipairs(t1) do
         if tltype.subtype(t2, v) and tltype.subtype(v, t2) then
           return true
         end
@@ -261,7 +261,7 @@ end
 function tltype.filterUnion (u, t)
   if tltype.isUnion(u) then
     local l = {}
-    for k, v in ipairs(u) do
+    for _, v in ipairs(u) do
       if not (tltype.subtype(t, v) and tltype.subtype(v, t)) then
         table.insert(l, v)
       end
@@ -397,7 +397,7 @@ end
 
 function tltype.isMethod (t)
   if tltype.isFunction(t) then
-    for k, v in ipairs(t[1]) do
+    for _, v in ipairs(t[1]) do
       if tltype.isSelf(v) then return true end
     end
     return false
@@ -441,7 +441,7 @@ end
 -- getField : (type, type) -> (type)
 function tltype.getField (f, t)
   if tltype.isTable(t) then
-    for k, v in ipairs(t) do
+    for _, v in ipairs(t) do
       if tltype.consistent_subtype(f, v[1]) then
         return v[2]
       end
@@ -455,7 +455,7 @@ end
 -- fieldlist : ({ident}, type) -> (field*)
 function tltype.fieldlist (idlist, t)
   local l = {}
-  for k, v in ipairs(idlist) do
+  for _, v in ipairs(idlist) do
     table.insert(l, tltype.Field(v.const, tltype.Literal(v[1]), t))
   end
   return table.unpack(l)
@@ -475,7 +475,7 @@ function tltype.checkTypeDec (n, t)
   if not predef_type[n] then
     if tltype.isTable(t) then
       local namelist = {}
-      for k, v in ipairs(t) do
+      for _, v in ipairs(t) do
         local f1, f2 = v[1], v[2]
         if tltype.isStr(f1) then
           local name = f1[1]
@@ -566,7 +566,7 @@ local function unfold_recursive (tr, t)
     return r
   elseif tltype.isTable(t) then
     local l = {}
-    for k, v in ipairs(t) do
+    for _, v in ipairs(t) do
       table.insert(l, tltype.Field(v.const, v[1], unfold_recursive(tr, v[2])))
     end
     local r = tltype.Table(table.unpack(l))
@@ -619,7 +619,7 @@ local function check_recursive (t, name)
   elseif tltype.isUnion(t) or
          tltype.isUnionlist(t) or
          tltype.isTuple(t) then
-    for k, v in ipairs(t) do
+    for _, v in ipairs(t) do
       if check_recursive(v, name) then
         return true
       end
@@ -628,7 +628,7 @@ local function check_recursive (t, name)
   elseif tltype.isFunction(t) then
     return check_recursive(t[1], name) or check_recursive(t[2], name)
   elseif tltype.isTable(t) then
-    for k, v in ipairs(t) do
+    for _, v in ipairs(t) do
       if check_recursive(v[2], name) then
         return true
       end
@@ -704,14 +704,14 @@ end
 
 local function subtype_union (env, t1, t2, relation)
   if tltype.isUnion(t1) then
-    for k, v in ipairs(t1) do
+    for _, v in ipairs(t1) do
       if not subtype(env, v, t2, relation) then
         return false
       end
     end
     return true
   elseif tltype.isUnion(t2) then
-    for k, v in ipairs(t2) do
+    for _, v in ipairs(t2) do
       if subtype(env, t1, v, relation) then
         return true
       end
@@ -921,7 +921,7 @@ local function subtype_tuple (env, t1, t2, relation)
       end
       return true
     else
-      for k, v in ipairs(t1) do
+      for k, _ in ipairs(t1) do
         if not subtype(env, t1[k], t2[k], relation) then
           return false
         end
@@ -937,14 +937,14 @@ function subtype (env, t1, t2, relation)
   if tltype.isVoid(t1) and tltype.isVoid(t2) then
     return true
   elseif tltype.isUnionlist(t1) then
-    for k, v in ipairs(t1) do
+    for _, v in ipairs(t1) do
       if not subtype(env, v, t2, relation) then
         return false
       end
     end
     return true
   elseif tltype.isUnionlist(t2) then
-    for k, v in ipairs(t2) do
+    for _, v in ipairs(t2) do
       if subtype(env, t1, v, relation) then
         return true
       end
@@ -1003,7 +1003,7 @@ function tltype.general (t)
     return tltype.String()
   elseif tltype.isUnion(t) then
     local l = {}
-    for k, v in ipairs(t) do
+    for _, v in ipairs(t) do
       table.insert(l, tltype.general(v))
     end
     return tltype.Union(table.unpack(l))
@@ -1011,7 +1011,7 @@ function tltype.general (t)
     return tltype.Function(tltype.general(t[1]), tltype.general(t[2]))
   elseif tltype.isTable(t) then
     local l = {}
-    for k, v in ipairs(t) do
+    for _, v in ipairs(t) do
       table.insert(l, tltype.Field(v.const, v[1], tltype.general(v[2])))
     end
     local n = tltype.Table(table.unpack(l))
@@ -1020,13 +1020,13 @@ function tltype.general (t)
     return n
   elseif tltype.isTuple(t) then
     local l = {}
-    for k, v in ipairs(t) do
+    for _, v in ipairs(t) do
       table.insert(l, tltype.general(v))
     end
     return tltype.Tuple(l)
   elseif tltype.isUnionlist(t) then
     local l = {}
-    for k, v in ipairs(t) do
+    for _, v in ipairs(t) do
       table.insert(l, tltype.general(v))
     end
     return tltype.Unionlist(table.unpack(l))
@@ -1088,7 +1088,7 @@ end
 
 function tltype.unionlist2union (t, i)
   local l = {}
-  for k, v in ipairs(t) do
+  for _, v in ipairs(t) do
     l[#l + 1] = v[i]
   end
   return tltype.Union(table.unpack(l))
@@ -1099,7 +1099,7 @@ function tltype.first (t)
     return tltype.first(t[1])
   elseif tltype.isUnionlist(t) then
     local l = {}
-    for k, v in ipairs(t) do
+    for _, v in ipairs(t) do
       table.insert(l, tltype.first(v))
     end
     return tltype.Union(table.unpack(l))


### PR DESCRIPTION
This commit reduces the number of warnings reported by luacheck from [153](https://travis-ci.org/jvprat/typedlua/jobs/129753815) to [50](https://travis-ci.org/jvprat/typedlua/jobs/129782075). Some of the left warnings may point to actual bugs, like these ones, but I'm not familiar enough with the code to decide on the proper solution:

    typedlua/tltype.lua:583:43: accessing undefined variable trec
    typedlua/tltype.lua:1052:39: accessing undefined variable Nil