### PR TITLE
Sort the type check errors by its position in the source.

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -4491,8 +4491,8 @@ end
 ]=]
 e = [=[
 test.lua:2:9: type error, attempt to assign '{number:({1:string} | nil)}' to '{number:(string | nil)}'
-test.lua:4:14: type error, return type '(number*)' does not match '(string*)'
 test.lua:4:1: type error, attempt to assign '((number*) -> (string*), nil*)' to '(({1:string}*) -> (nil*), value*)'
+test.lua:4:14: type error, return type '(number*)' does not match '(string*)'
 ]=]
 
 r = typecheck(s)

--- a/typedlua/tlchecker.lua
+++ b/typedlua/tlchecker.lua
@@ -35,6 +35,12 @@ end
 local function typeerror (env, tag, msg, pos)
   local l, c = lineno(env.subject, pos)
   local error_msg = { tag = tag, filename = env.filename, msg = msg, l = l, c = c }
+  for i, v in ipairs(env.messages) do
+    if l < v.l or (l == v.l and c < v.c) then
+      table.insert(env.messages, i, error_msg)
+      return
+    end
+  end
   table.insert(env.messages, error_msg)
 end
 


### PR DESCRIPTION
This sorts the type check errors by its position in the source. Without it, some errors are shown unordered, and some even depend on the Lua implementation (Lua vs LuaJIT).