### PR TITLE
Added optional ANSI color output for most errors

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -35,7 +35,7 @@ local function typecheck (my_s)
     error(m)
     os.exit(1)
   end
-  m = tlchecker.typecheck(t,my_s,filename,false,false)
+  m = tlchecker.typecheck(t,my_s,filename,false,false,false)
   m = tlchecker.error_msgs(m,false)
   if m then
     my_r = m
@@ -51,7 +51,7 @@ local function generate (my_s)
     error(m)
     os.exit(1)
   end
-  m = tlchecker.typecheck(t,my_s,filename,false,false)
+  m = tlchecker.typecheck(t,my_s,filename,false,false,false)
   m = tlchecker.error_msgs(m,false)
   if m then
     return m .. "\n"
@@ -3716,7 +3716,7 @@ for w in ("foo bar"):gmatch("(%w+)") do
 end
 ]=]
 e = [=[
-test.lua:1:5: type error, attempt to iterate over 1
+test.lua:1:5: type error, attempt to iterate over '1'
 ]=]
 
 r = typecheck(s)

--- a/tlc
+++ b/tlc
@@ -12,6 +12,7 @@ local OUTPUT
 local DUMPAST = false
 local PRINTAST = false
 
+local COLOR = false
 local STRICT = false
 local WARNINGS = false
 local INTEGER = false
@@ -25,6 +26,7 @@ Available options are:
 -h       print this help
 -d name	 dump the AST (after typechecking) to file 'name'
 -o name	 output to file 'name' (default is '%s')
+-c       ansi colors on
 -p       print the AST in Metalua format (before typechecking)
 -s       strict mode on
 -v       print current version
@@ -71,6 +73,8 @@ local function doargs ()
             OUTPUT = arg[i]
             break
           end
+        elseif option_char == "c" then
+          COLOR = true
         elseif option_char == "p" then
           PRINTAST = true
         elseif option_char == "s" then
@@ -135,9 +139,9 @@ if PRINTAST then
   print(tlast.tostring(ast))
 end
 
-error_msg = tlchecker.typecheck(ast, subject, filename, STRICT, INTEGER)
+error_msg = tlchecker.typecheck(ast, subject, filename, STRICT, INTEGER, COLOR)
 local status
-error_msg, status = tlchecker.error_msgs(error_msg, WARNINGS)
+error_msg, status = tlchecker.error_msgs(error_msg, WARNINGS, COLOR)
 if error_msg then print(error_msg) end
 
 local generated_code = tlcode.generate(ast)

--- a/typedlua/loader.lua
+++ b/typedlua/loader.lua
@@ -12,6 +12,8 @@ local tlparser  = require "typedlua.tlparser"
 local tlchecker = require "typedlua.tlchecker"
 local tlcode    = require "typedlua.tlcode"
 
+local COLOR = false
+
 local tlloader = {}
 
 local opts =
@@ -23,11 +25,13 @@ local opts =
 if _VERSION == "Lua 5.3" then opts.INTEGER = true end
 
 -- Compiles Typed Lua into Lua code
-function tlloader.compile (code, chunkname)
+function tlloader.compile (code, chunkname, color)
   local code_t = type(code)
   if code_t ~= "string" then
     return nil, "expecting string (got " .. code_t .. ")"
   end
+
+  COLOR = color
 
   -- Parse
   local ast, err = tlparser.parse(code, chunkname, opts.STRICT, opts.INTEGER)
@@ -36,7 +40,7 @@ function tlloader.compile (code, chunkname)
   end
 
   -- Typecheck
-  local messages = tlchecker.typecheck(ast, code, chunkname, opts.STRICT, opts.INTEGER)
+  local messages = tlchecker.typecheck(ast, code, chunkname, opts.STRICT, opts.INTEGER, color)
 
   -- Check if there were errors
   local has_errors = tlchecker.error_msgs(messages, false)
@@ -151,7 +155,7 @@ end
 
 function tlloader.loadstring (string, chunkname, ...)
   chunkname = chunkname or "=(typedlua.loadstring)"
-  local lua_code, err = tlloader.compile(string, chunkname)
+  local lua_code, err = tlloader.compile(string, chunkname, COLOR)
   if not lua_code then
     return nil, err
   end

--- a/typedlua/tlst.lua
+++ b/typedlua/tlst.lua
@@ -5,12 +5,13 @@ This module implements Typed Lua symbol table.
 local tlst = {}
 
 -- new_env : (string, string, boolean) -> (env)
-function tlst.new_env (subject, filename, strict)
+function tlst.new_env (subject, filename, strict, color)
   local env = {}
   env.subject = subject
   env.filename = filename
   env.parent = filename
   env.strict = strict
+  env.color = color
   env.integer = false
   env.messages = {}
   env.maxscope = 0


### PR DESCRIPTION
Added new option -c for forcing colored output (at some point might be worth adding something to detect if in a colored term in interactive mode, to enable the automatically, for now you need to pass manually).

This colors type errors and warnings in a style very similar to the default colored output of GCC.

Colored output makes the errors/warnings easier to look through, and easier to pick out relevant information when trying to compile.

AFAIK it's just syntax errors I didn't add. I can make another PR for those later if people are in fact interested.