### PR TITLE
Fix tlc for Make

### DIFF
--- a/tlc
+++ b/tlc
@@ -144,8 +144,10 @@ local status
 error_msg, status = tlchecker.error_msgs(error_msg, WARNINGS, COLOR)
 if error_msg then print(error_msg) end
 
-local generated_code = tlcode.generate(ast)
-setcontents(generated_code, OUTPUT)
+if status == 0 then
+  local generated_code = tlcode.generate(ast)
+  setcontents(generated_code, OUTPUT)
+end
 
 if DUMPAST then
   local out = assert(io.open(DUMPAST, "w+"))

--- a/typedlua/tlchecker.lua
+++ b/typedlua/tlchecker.lua
@@ -1778,6 +1778,7 @@ function tlchecker.error_msgs (messages, warnings, color)
     mask = true,
     unused = true,
   }
+  local n = 0
   for _, v in ipairs(messages) do
     local tag = v.tag
     if skip_error[tag] then
@@ -1788,10 +1789,10 @@ function tlchecker.error_msgs (messages, warnings, color)
     else
       local error_text = color and acolor.red .. "type error" .. acolor.reset or "type error"
       table.insert(l, string.format(msg, v.filename, v.l, v.c, error_text, v.msg))
+      n = n + 1
     end
   end
-  local n = #l
-  if n == 0 then
+  if #l == 0 then
     return nil, n
   else
     return table.concat(l, "\n"), n


### PR DESCRIPTION
Was trying to use `tlc` in a `Makefile`, but was getting some unexpected results.

I have made the following changes to let `tlc` update output files and drive Make in the expected way:
* Only returns non-zero exit status on errors, now. Warnings are ignored by the status count.
* Only writes to output file if no errors are encountered.

The second point might seem unnecessary, since if we can generate the .lua file that's better, right? However compilers generally do not touch output files if they fail (and this confuses Make). If the previous behavior was useful we should add an explicit option to do this, I don't think programmers expect the previous behavior either.